### PR TITLE
Option to import clusters in raw format

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,10 @@ Ref: http://neon.chem.le.ac.uk/nmrclust (link has been down for some time)
 
 Import *Cluster.log* into *Clustering*. Only a level (0) will be available. Outliers will be splitted in different clusters. Check *Join 1 member clusters* to cluster them together.
 
+### Raw cluster indices
+
+A text file containing one line per frame, where the *n*-th line contains one integer which is the index of the cluster containing the *n*-th frame. Supports a single level.
+
 ## Author
 
 Luis Gracia (https://github.com/luisico)

--- a/clustering.tcl
+++ b/clustering.tcl
@@ -114,6 +114,7 @@ proc clustering::cluster {} {
   $w.menubar.import.menu add command -label "Cutree (R)..."          -command "[namespace current]::import cutree"
   $w.menubar.import.menu add command -label "Gromacs (g_cluster)..." -command "[namespace current]::import gcluster"
   $w.menubar.import.menu add command -label "Charmm..." -command "[namespace current]::import charmm"
+  $w.menubar.import.menu add command -label "Raw (index list)..." -command "[namespace current]::import raw"
 
   # Menubar / Help menu
   menubutton $w.menubar.help -text "Help" -menu $w.menubar.help.menu
@@ -926,6 +927,25 @@ proc clustering::import_charmm {fileid} {
   [namespace current]::UpdateLevels
 }
 
+# Raw (list of cluster ids)
+proc clustering::import_raw {fileid} {
+  variable level_list
+  variable cluster
+
+  set member 0
+  while {![eof $fileid]} {
+    gets $fileid line
+    if { [llength $line] == 1 } {
+      set ID [expr {int($line)}]
+      lappend cluster(0:$ID) $member
+      incr member
+    }
+  }
+
+  $level_list insert end 0
+  $level_list selection set 0
+  [namespace current]::UpdateLevels
+}
 
 #############################################################################
 # Calculate


### PR DESCRIPTION
The format is a flat file with one line per frame, containing the cluster number for said frame. I find it useful to import clusters from more "manual" tools - rather than coercing the raw data into the format of one of the existing tools.